### PR TITLE
Update for linux-arm64 support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,6 +41,12 @@ jobs:
               rustup update stable &&
               yarn build --target x86_64-unknown-linux-gnu &&
               strip *.node
+          - host: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            build: |-
+              set -e &&
+              yarn build --target aarch64-unknown-linux-gnu &&
+              strip *.node
           - host: macos-latest
             target: aarch64-apple-darwin
             build: |
@@ -198,12 +204,51 @@ jobs:
         shell: bash
       - name: Test bindings
         run: docker run --rm -v $(pwd):/build -w /build node:${{ matrix.node }}-slim yarn test
+
+  test-linux-arm64-gnu-binding:
+    name: Test bindings on Linux-arm64-gnu - node@${{ matrix.node }}
+    needs:
+      - build
+    strategy:
+      fail-fast: false
+      matrix:
+        node:
+          - '14'
+          - '16'
+          - '18'
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          check-latest: true
+          cache: yarn
+      - name: Cache NPM dependencies
+        uses: actions/cache@v3
+        with:
+          path: .yarn/cache
+          key: npm-cache-test-linux-arm64-gnu-${{ matrix.node }}
+      - name: Install dependencies
+        run: yarn install
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: bindings-aarch64-unknown-linux-gnu
+          path: .
+      - name: List packages
+        run: ls -R .
+        shell: bash
+      - name: Test bindings
+        run: yarn test
   publish:
     name: Publish
     runs-on: ubuntu-latest
     needs:
       - test-macOS-windows-binding
       - test-linux-x64-gnu-binding
+      - test-linux-arm64-gnu-binding
     steps:
       - uses: actions/checkout@v4
       - name: Setup node

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ crate-type = ["cdylib"]
 [dependencies]
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = { version = "2.10.16", default-features = false, features = ["napi8"] }
-
 napi-derive = "2.10.1"
 ignore = "0.4.20"
 dashmap = { version = "5.4.0", features = ["rayon"] }
 anyhow = "1.0.51"
 rayon = "1.6.1"
-gix = { version = "0.66", features = ["fast-sha1"] }
+gix-hash = "0.18.0"
+gix-object = "0.49.1"
 hex = "0.4.3"
 
 [build-dependencies]

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,12 +8,12 @@ export interface PartialHashGlobOptions {
   gitignore?: boolean
   concurrency?: number
 }
-export function hashGlobXxhash(globs: Array<string>, maybeOptions?: PartialHashGlobOptions | undefined | null): Record<string, bigint | undefined | null> | null
-export function hashGlobGit(globs: Array<string>, maybeOptions?: PartialHashGlobOptions | undefined | null): Record<string, string | undefined | null> | null
-export function hash(files: Array<string>, maybeOptions?: PartialHashGlobOptions | undefined | null): Record<string, string | undefined | null> | null
-export function glob(globs: Array<string>, maybeOptions?: PartialHashGlobOptions | undefined | null): Array<string> | null
+export declare function hashGlobXxhash(globs: Array<string>, maybeOptions?: PartialHashGlobOptions | undefined | null): Record<string, bigint | undefined | null> | null
+export declare function hashGlobGit(globs: Array<string>, maybeOptions?: PartialHashGlobOptions | undefined | null): Record<string, string | undefined | null> | null
+export declare function hash(files: Array<string>, maybeOptions?: PartialHashGlobOptions | undefined | null): Record<string, string | undefined | null> | null
+export declare function glob(globs: Array<string>, maybeOptions?: PartialHashGlobOptions | undefined | null): Array<string> | null
 export interface StatEntry {
   mtime: bigint
   size: number
 }
-export function stat(files: Array<string>, maybeOptions?: PartialHashGlobOptions | undefined | null): Record<string, StatEntry> | null
+export declare function stat(files: Array<string>, maybeOptions?: PartialHashGlobOptions | undefined | null): Record<string, StatEntry> | null

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "triples": {
       "additional": [
         "aarch64-apple-darwin",
-        "aarch64-pc-windows-msvc"
+        "aarch64-pc-windows-msvc",
+        "aarch64-unknown-linux-gnu",
+        "aarch64-unknown-linux-musl"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
       "additional": [
         "aarch64-apple-darwin",
         "aarch64-pc-windows-msvc",
-        "aarch64-unknown-linux-gnu",
-        "aarch64-unknown-linux-musl"
+        "aarch64-unknown-linux-gnu"
       ]
     }
   },

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -1,7 +1,6 @@
 use dashmap::{DashMap, DashSet};
-use gix_hash::{Kind as HashKind};
-use gix_object::{Kind as ObjectKind};
-use gix_object::encode::loose_header;
+use gix_hash::Kind as HashKind;
+use gix_object::Kind as ObjectKind;
 use rayon::prelude::*;
 
 use std::fs;
@@ -46,12 +45,10 @@ pub fn git_hash(file_set: DashSet<PathBuf>, cwd: &str) -> Option<HashMap<String,
     let key = normalize_path(&base_cwd, file_path);
 
     if let Ok(bytes) = bytes_results {
-      let mut hasher = gix_hash::hasher(HashKind::Sha1);
-      let header = loose_header(ObjectKind::Blob, bytes.len() as u64);
-      hasher.update(&header);
-      hasher.update(&bytes);
-      let hash = hasher.try_finalize().map(|id| id.to_hex().to_string()).ok();
-      map.insert(key, hash);
+      match gix_object::compute_hash(HashKind::Sha1, ObjectKind::Blob, &bytes) {
+        Ok(hash) => map.insert(key, Some(hash.to_hex().to_string())),
+        Err(_) => map.insert(key, None),
+      };
     } else {
       map.insert(key, None);
     }
@@ -76,12 +73,10 @@ pub fn git_hash_vec(files: Vec<PathBuf>, cwd: &str) -> Option<HashMap<String, Op
     let key = normalize_path(&base_cwd, file_path);
 
     if let Ok(bytes) = bytes_results {
-      let mut hasher = gix_hash::hasher(HashKind::Sha1);
-      let header = loose_header(ObjectKind::Blob, bytes.len() as u64);
-      hasher.update(&header);
-      hasher.update(&bytes);
-      let hash = hasher.try_finalize().map(|id| id.to_hex().to_string()).ok();
-      map.insert(key, hash);
+      match gix_object::compute_hash(HashKind::Sha1, ObjectKind::Blob, &bytes) {
+        Ok(hash) => map.insert(key, Some(hash.to_hex().to_string())),
+        Err(_) => map.insert(key, None),
+      };
     } else {
       map.insert(key, None);
     }


### PR DESCRIPTION
It looks like glob-hasher doesn't have a linux-arm64.node file.

When trying to build locally, the previous version of gix was not building successfully on arm64 linux with the rust 1.88.0

Updating to gix_hash and gix_object works with newer versions of rust.

Enables #3