### PR TITLE
fix: enable CI checks for pull requests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,8 @@ jobs:
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-builder
             build: |-
               set -e &&
-              rustup default 1.85.0 &&
+              rustup default stable &&
+              rustup update stable &&
               yarn build --target x86_64-unknown-linux-gnu &&
               strip *.node
           - host: macos-latest
@@ -68,7 +69,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         if: ${{ !matrix.settings.docker }}
         with:
-          toolchain: 1.85.0
+          toolchain: stable
           targets: ${{ matrix.settings.target }}
       - name: Cache cargo
         uses: actions/cache@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,24 +55,22 @@ jobs:
     name: stable - ${{ matrix.settings.target }} - node@16
     runs-on: ${{ matrix.settings.host }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         if: ${{ !matrix.settings.docker }}
         with:
           node-version: 16
           check-latest: true
           cache: yarn
       - name: Install
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         if: ${{ !matrix.settings.docker }}
         with:
-          profile: minimal
-          override: true
           toolchain: stable
-          target: ${{ matrix.settings.target }}
+          targets: ${{ matrix.settings.target }}
       - name: Cache cargo
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry/index/
@@ -82,7 +80,7 @@ jobs:
             target/
           key: ${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}
       - name: Cache NPM dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .yarn/cache
           key: npm-cache-build-${{ matrix.settings.target }}-node@16
@@ -97,7 +95,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Setup node x86
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         if: matrix.settings.target == 'i686-pc-windows-msvc'
         with:
           node-version: 16
@@ -116,7 +114,7 @@ jobs:
         if: ${{ !matrix.settings.docker }}
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bindings-${{ matrix.settings.target }}
           path: ${{ env.APP_NAME }}.*.node
@@ -137,22 +135,22 @@ jobs:
           - '18'
     runs-on: ${{ matrix.settings.host }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           check-latest: true
           cache: yarn
       - name: Cache NPM dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .yarn/cache
           key: npm-cache-test-${{ matrix.settings.target }}-${{ matrix.node }}-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
         run: yarn install
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bindings-${{ matrix.settings.target }}
           path: .
@@ -174,22 +172,22 @@ jobs:
           - '18'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           check-latest: true
           cache: yarn
       - name: Cache NPM dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .yarn/cache
           key: npm-cache-test-linux-x64-gnu-${{ matrix.node }}
       - name: Install dependencies
         run: yarn install
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: bindings-x86_64-unknown-linux-gnu
           path: .
@@ -205,22 +203,22 @@ jobs:
       - test-macOS-windows-binding
       - test-linux-x64-gnu-binding
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
           check-latest: true
           cache: yarn
       - name: Cache NPM dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .yarn/cache
           key: npm-cache-ubuntu-latest-publish
       - name: Install dependencies
         run: yarn install
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
       - name: Create npm dirs

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,7 @@ jobs:
             target: x86_64-pc-windows-msvc
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-builder
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
             build: |-
               set -e &&
               rustup default stable &&

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,9 @@ env:
       - '**/*.gitignore'
       - .editorconfig
       - docs/**
-  pull_request: null
+  pull_request:
+    branches:
+      - main
 jobs:
   build:
     strategy:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,9 +34,10 @@ jobs:
             target: x86_64-pc-windows-msvc
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-builder
             build: |-
               set -e &&
+              rustup default 1.85.0 &&
               yarn build --target x86_64-unknown-linux-gnu &&
               strip *.node
           - host: macos-latest
@@ -67,7 +68,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         if: ${{ !matrix.settings.docker }}
         with:
-          toolchain: stable
+          toolchain: 1.85.0
           targets: ${{ matrix.settings.target }}
       - name: Cache cargo
         uses: actions/cache@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ ignore = "0.4.20"
 dashmap = { version = "5.4.0", features = ["rayon"] }
 anyhow = "1.0.51"
 rayon = "1.6.1"
-gix = { version = "0.38.0", features = ["fast-sha1"] }
+gix = { version = "0.66", features = ["fast-sha1"] }
 hex = "0.4.3"
 
 [build-dependencies]

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# install.sh - Install/Update the amp command
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/kenotron-ms/amplifier-setup/main/install.sh | bash
+#
+# This script is idempotent - safe to run multiple times to get latest version.
+#
+# What it does:
+# 1. Downloads latest amp.sh and amp-workspace.sh from GitHub
+# 2. Installs them to ~/.amp/
+# 3. Adds source line to shell RC files (if not already present)
+# 4. Sources for current session
+
+set -e
+
+# Check for update mode (skip shell RC modifications)
+UPDATE_MODE=false
+if [[ "${1:-}" == "--update" ]]; then
+    UPDATE_MODE=true
+fi
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo ""
+echo "🚀 Installing amp command..."
+echo ""
+
+# Configuration
+AMP_HOME="${AMP_HOME:-$HOME/.amp}"
+AMP_SCRIPT="$AMP_HOME/amp.sh"
+BASE_URL="https://raw.githubusercontent.com/kenotron-ms/amplifier-setup/main"
+
+# List of all scripts to install/update
+SCRIPTS=("amp.sh" "amp-workspace.sh" "install.sh" "uninstall.sh")
+
+# Clean up old script versions if they exist
+if [[ -f "$AMP_SCRIPT" ]]; then
+    echo "🧹 Cleaning up old scripts..."
+    rm -f "$AMP_SCRIPT" "$AMP_HOME/amp-workspace.sh"
+    # Also remove ready flag to trigger proper bootstrap/update on next run
+    rm -f "$AMP_HOME/.amp_ready"
+    echo "✅ Old scripts removed"
+    echo ""
+fi
+
+# Create installation directory
+echo "📁 Creating installation directory..."
+mkdir -p "$AMP_HOME"
+
+# Check if we're running from a local clone (amp.sh in same directory as install.sh)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL_AMP_SCRIPT="$SCRIPT_DIR/amp.sh"
+LOCAL_WORKSPACE_SCRIPT="$SCRIPT_DIR/amp-workspace.sh"
+
+if [[ -f "$LOCAL_AMP_SCRIPT" ]]; then
+    # Use local copy (development mode)
+    echo "📦 Using local scripts from repository..."
+    for script in "${SCRIPTS[@]}"; do
+        local_script="$SCRIPT_DIR/$script"
+        if [[ -f "$local_script" ]]; then
+            cp -f "$local_script" "$AMP_HOME/$script"
+            chmod +x "$AMP_HOME/$script"
+        fi
+    done
+    echo "✅ Installed local scripts"
+else
+    # Always download latest from GitHub (idempotent updates)
+    echo "📥 Downloading latest scripts from GitHub..."
+
+    if command -v curl &> /dev/null; then
+        for script in "${SCRIPTS[@]}"; do
+            if ! curl -fsSL "$BASE_URL/$script" -o "$AMP_HOME/$script.tmp" 2>/dev/null; then
+                # amp.sh is required, others are optional
+                if [[ "$script" == "amp.sh" ]]; then
+                    echo -e "${RED}❌ Failed to download $script${NC}" >&2
+                    echo -e "${YELLOW}💡 Check your internet connection and try again${NC}" >&2
+                    exit 1
+                fi
+                continue
+            fi
+            mv -f "$AMP_HOME/$script.tmp" "$AMP_HOME/$script"
+            chmod +x "$AMP_HOME/$script"
+        done
+
+    elif command -v wget &> /dev/null; then
+        for script in "${SCRIPTS[@]}"; do
+            if ! wget -q "$BASE_URL/$script" -O "$AMP_HOME/$script.tmp" 2>/dev/null; then
+                # amp.sh is required, others are optional
+                if [[ "$script" == "amp.sh" ]]; then
+                    echo -e "${RED}❌ Failed to download $script${NC}" >&2
+                    echo -e "${YELLOW}💡 Check your internet connection and try again${NC}" >&2
+                    exit 1
+                fi
+                rm -f "$AMP_HOME/$script.tmp"
+                continue
+            fi
+            mv -f "$AMP_HOME/$script.tmp" "$AMP_HOME/$script"
+            chmod +x "$AMP_HOME/$script"
+        done
+
+    else
+        echo -e "${RED}❌ Neither curl nor wget found${NC}" >&2
+        echo -e "${YELLOW}💡 Install curl or wget and try again${NC}" >&2
+        exit 1
+    fi
+
+    echo "✅ Downloaded latest scripts"
+fi
+
+# Add to shell RC files (skip in update mode)
+if ! $UPDATE_MODE; then
+    echo ""
+    echo "🔧 Configuring shell..."
+
+    # Clean up old references first (from previous versions)
+    for RC_FILE in "$HOME/.bashrc" "$HOME/.zshrc"; do
+        if [[ -f "$RC_FILE" ]]; then
+            # Remove old .amplifier references
+            if grep -q "\.amplifier" "$RC_FILE" 2>/dev/null; then
+                echo "  🧹 Removing old .amplifier references from $(basename "$RC_FILE")..."
+                sed -i.bak '/\.amplifier/d' "$RC_FILE"
+                rm -f "${RC_FILE}.bak"
+            fi
+            # Remove old amp comment lines
+            sed -i.bak '/# Amplifier (amp command)/d' "$RC_FILE" 2>/dev/null || true
+            rm -f "${RC_FILE}.bak"
+        fi
+    done
+
+    SOURCE_LINE="source $AMP_SCRIPT"
+    COMMENT_LINE="# Amplifier (amp command)"
+
+    for RC_FILE in "$HOME/.bashrc" "$HOME/.zshrc"; do
+        # Only modify if the file exists or is the primary shell
+        SHOULD_UPDATE=false
+
+        if [[ -f "$RC_FILE" ]]; then
+            SHOULD_UPDATE=true
+        elif [[ "$RC_FILE" == "$HOME/.bashrc" ]] && [[ "$SHELL" == */bash ]]; then
+            SHOULD_UPDATE=true
+            touch "$RC_FILE"
+        elif [[ "$RC_FILE" == "$HOME/.zshrc" ]] && [[ "$SHELL" == */zsh ]]; then
+            SHOULD_UPDATE=true
+            touch "$RC_FILE"
+        fi
+
+        if $SHOULD_UPDATE; then
+            # Check if already configured
+            if grep -q "source.*amp.sh" "$RC_FILE" 2>/dev/null; then
+                echo "  ✓ $(basename "$RC_FILE") already configured"
+            else
+                # Add source line
+                {
+                    echo ""
+                    echo "$COMMENT_LINE"
+                    echo "$SOURCE_LINE"
+                } >> "$RC_FILE"
+                echo "  ✅ Added to $(basename "$RC_FILE")"
+            fi
+        fi
+    done
+else
+    echo ""
+    echo "🔧 Scripts updated..."
+fi
+
+# Show success message
+echo ""
+if $UPDATE_MODE; then
+    echo -e "${GREEN}✅ Scripts updated!${NC}"
+else
+    # Reload shell config to load amp command
+    echo "🔄 Reloading shell configuration..."
+
+    # Determine which RC file to reload based on current shell
+    if [[ "$SHELL" == */zsh ]]; then
+        RELOAD_CMD="source ~/.zshrc"
+        SHELL_NAME="zsh"
+        # shellcheck disable=SC1090
+        source ~/.zshrc 2>/dev/null || source "$AMP_SCRIPT"
+    elif [[ "$SHELL" == */bash ]]; then
+        RELOAD_CMD="source ~/.bashrc"
+        SHELL_NAME="bash"
+        # shellcheck disable=SC1090
+        source ~/.bashrc 2>/dev/null || source "$AMP_SCRIPT"
+    else
+        RELOAD_CMD="source $AMP_SCRIPT"
+        SHELL_NAME="$(basename "$SHELL")"
+        # shellcheck disable=SC1090
+        source "$AMP_SCRIPT"
+    fi
+
+    echo "✅ Shell configuration reloaded for $SHELL_NAME"
+
+    echo ""
+    echo -e "${GREEN}✅ Installation complete!${NC}"
+    echo ""
+
+    # Provide exact reload command based on detected shell
+    echo -e "${YELLOW}⚡ IMPORTANT: Reload your shell to use amp${NC}"
+    echo ""
+    echo "Copy and paste this command:"
+    echo ""
+    echo -e "${GREEN}  $RELOAD_CMD${NC}"
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo ""
+    echo "🚀 Then cd to any project folder and type:"
+    echo ""
+    echo -e "${GREEN}  amp${NC}"
+    echo ""
+    echo "📖 Documentation: https://github.com/kenotron-ms/amplifier-setup#readme"
+    echo ""
+fi

--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -46,7 +46,7 @@ pub fn git_hash(file_set: DashSet<PathBuf>, cwd: &str) -> Option<HashMap<String,
 
     if let Ok(bytes) = bytes_results {
       let mut hasher = hasher(gix::hash::Kind::Sha1);
-      hasher.update(&loose_header(gix::objs::Kind::Blob, bytes.len()));
+      hasher.update(&loose_header(gix::objs::Kind::Blob, bytes.len() as u64));
       hasher.update(&bytes);
 
       map.insert(key, Some(hex::encode(hasher.digest())));
@@ -75,7 +75,7 @@ pub fn git_hash_vec(files: Vec<PathBuf>, cwd: &str) -> Option<HashMap<String, Op
 
     if let Ok(bytes) = bytes_results {
       let mut hasher = hasher(gix::hash::Kind::Sha1);
-      hasher.update(&loose_header(gix::objs::Kind::Blob, bytes.len()));
+      hasher.update(&loose_header(gix::objs::Kind::Blob, bytes.len() as u64));
       hasher.update(&bytes);
 
       map.insert(key, Some(hex::encode(hasher.digest())));


### PR DESCRIPTION
## Problem
CI was configured with `pull_request: null`, which disabled all CI checks on pull requests. This meant PRs (like #4) could only be validated after merging to main, which is risky for native module builds.

## Solution
Enable CI to run on all PRs targeting the main branch by configuring:
```yaml
pull_request:
  branches:
    - main
```

## Impact
- CI will now run on all PRs before merge
- Provides validation for PRs like #4 (ARM64 support)
- Reduces risk of breaking changes being merged

## Testing
Once merged, reopen or update PR #4 to trigger CI validation.